### PR TITLE
Compile Errors In OperationQueues

### DIFF
--- a/iOS/OperationQueues/OperationQueues/FaviconTableViewCell.swift
+++ b/iOS/OperationQueues/OperationQueues/FaviconTableViewCell.swift
@@ -26,7 +26,7 @@ didSet {
     var request = NSURLRequest(URL: self.url!)
         
     // Display this text
-    self.textLabel.text = self.url?.host
+    self.textLabel?.text = self.url?.host
         
     // Fire off the request, and give it a completion handler
     // plus a queue to run on
@@ -34,22 +34,24 @@ didSet {
         queue: self.operationQueue!,
         completionHandler: {
             (response: NSURLResponse!, data: NSData!, error: NSError!) in
-                
-            // The 'data' variable now contains the loaded data;
-            // turn it into an image
-            var image = UIImage(data: data)
-                
-            // Updates to the UI have to be done on the main queue.
-            NSOperationQueue.mainQueue().addOperationWithBlock() {
+            
+            if data != nil {
+                // The 'data' variable now contains the loaded data;
+                // turn it into an image
+                var image = UIImage(data: data)
                     
-                // Give the image view the loaded image
-                self.imageView.image = image
-                    
-                // The image view has probably changed size because of
-                // the new image, so we need to re-layout the cell.
-                self.setNeedsLayout()
+                // Updates to the UI have to be done on the main queue.
+                NSOperationQueue.mainQueue().addOperationWithBlock() {
+                        
+                    // Give the image view the loaded image
+                    self.imageView?.image = image
+                        
+                    // The image view has probably changed size because of
+                    // the new image, so we need to re-layout the cell.
+                    self.setNeedsLayout()
+                }
             }
-                
+            
         })
         
 }


### PR DESCRIPTION
While going through the Dec. 11, 2014 version of the PDF with XCode 6.2b3 and iOS 8.2b3 I had some compilation errors.

It looks like some properties changed to optional values.  I changed them to optionals and added a guard if != nil and that seems to fix the main problem.
